### PR TITLE
Add : 탭 영역 프래그먼트 전환 기능

### DIFF
--- a/app/src/main/java/com/example/workswhale/MainActivity.kt
+++ b/app/src/main/java/com/example/workswhale/MainActivity.kt
@@ -2,10 +2,26 @@ package com.example.workswhale
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.example.workswhale.databinding.ActivityMainBinding
+import com.google.android.material.tabs.TabLayoutMediator
 
 class MainActivity : AppCompatActivity() {
+    private val binding: ActivityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(binding.root)
+
+        val adapter = ViewPagerAdapter(this)
+        binding.viewPagerMain.adapter = adapter
+
+        TabLayoutMediator(binding.tabLayoutBottom, binding.viewPagerMain) { tab, position ->
+            when (position) {
+                0 -> tab.text = "연락처"
+                1 -> tab.text = "마이 페이지"
+            }
+        }.attach()
     }
 }

--- a/app/src/main/java/com/example/workswhale/ViewPagerAdapter.kt
+++ b/app/src/main/java/com/example/workswhale/ViewPagerAdapter.kt
@@ -1,0 +1,19 @@
+package com.example.workswhale
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class ViewPagerAdapter(fragmentActivity: FragmentActivity): FragmentStateAdapter(fragmentActivity) {
+    override fun getItemCount(): Int {
+        return 2
+    }
+
+    override fun createFragment(position: Int): Fragment {
+        return when (position) {
+            0 -> ContactListFragment()
+            else -> MyPageFragment()
+        }
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,8 +48,8 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <FrameLayout
-        android:id="@+id/framelayout_main"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager_main"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/tab_layout_bottom"


### PR DESCRIPTION
1) FrameLayout을 ViewPager2로 변경

2) 메인 액티비티의 탭 아이템의 아이디가 존재하면 에러가 떠서 아이디를 없앰

3) ViewPagerAdapter를 만듬

4) TabLayoutMediator를 통해 TabLayout과 ViewPager를 연결시킴

5) 탭 아이템의 텍스트를 TabLayoutMediator에서 정해줌

6) 연락처 추가 프래그먼트는 탭바를 통해 접근하는 것이 아니기에 추가시키지 않음