### PR TITLE
Add : 연락처 추가 다이얼로그 사진 선택 기능 & 선택한 사진까지 저장하여 연락처 리스트 바로 반영

### DIFF
--- a/app/src/main/java/com/example/workswhale/Contact.kt
+++ b/app/src/main/java/com/example/workswhale/Contact.kt
@@ -6,7 +6,7 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 sealed class Contact : Parcelable {
     data class Title(val department: Int) : Contact()
-    data class Person(val profileImage: Int,
+    data class Person(val profileImage: String,
                       val name: String,
                       val phoneNumber: String,
                       val department: Int,

--- a/app/src/main/java/com/example/workswhale/ContactAdapter.kt
+++ b/app/src/main/java/com/example/workswhale/ContactAdapter.kt
@@ -3,6 +3,7 @@ package com.example.workswhale
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
 import com.example.workswhale.databinding.ContactListPersonBinding
 import com.example.workswhale.databinding.ContactListTitleBinding
@@ -82,7 +83,11 @@ class ContactAdapter(val dataList : ArrayList<Contact>) : RecyclerView.Adapter<R
     inner class PersonViewHolder(private  val binding: ContactListPersonBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item : Contact.Person) {
             with(binding) {
-             ivContactlistProfile.setImageResource(item.profileImage)
+                if (ContactStorage.checkStartAlphabet(item.profileImage)) {
+                    binding.ivContactlistProfile.setImageURI(item.profileImage.toUri())
+                } else {
+                    binding.ivContactlistProfile.setImageResource(item.profileImage.toInt())
+                }
                 tvContactlistName.setText(item.name)
                 tvContactlistMemo.setText(item.memo)
             }

--- a/app/src/main/java/com/example/workswhale/ContactDetailFragment.kt
+++ b/app/src/main/java/com/example/workswhale/ContactDetailFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.example.workswhale.databinding.FragmentContactDetailBinding
 
@@ -48,7 +49,11 @@ class ContactDetailFragment : Fragment() {
         binding = FragmentContactDetailBinding.inflate(inflater, container, false)
 
         receivedItem?.let {
-            binding!!.ivProfile.setImageResource(it.profileImage)
+            if (ContactStorage.checkStartAlphabet(it.profileImage)) {
+                binding!!.ivProfile.setImageURI(it.profileImage.toUri())
+            } else {
+                binding!!.ivProfile.setImageResource(it.profileImage.toInt())
+            }
             binding!!.tvDetailName.text = it.name
             binding!!.tvDetailPhoneNumber.text = it.phoneNumber
             binding!!.tvDetailEmail.text = it.email

--- a/app/src/main/java/com/example/workswhale/ContactStorage.kt
+++ b/app/src/main/java/com/example/workswhale/ContactStorage.kt
@@ -9,24 +9,24 @@ object ContactStorage {
 
     private fun addDummyContact() {
        totalContactList.add(Contact.Title(0))
-        totalContactList.add(Contact.Person(R.drawable.person_1,"박소담 사원","010-1212-1212",0,"abc@sparta.com","이제 막 입사한", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_2,"정해인 사원","010-1212-1212",0,"abc@sparta.com","신입사원 담당", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_3,"이정민 대리","010-1212-1212",0,"abc@sparta.com","근태관리", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_3,"이정민 대리","010-1212-1212",0,"abc@sparta.com","근태관리", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_1.toString(),"박소담 사원","010-1212-1212",0,"abc@sparta.com","이제 막 입사한", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_2.toString(),"정해인 사원","010-1212-1212",0,"abc@sparta.com","신입사원 담당", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_3.toString(),"이정민 대리","010-1212-1212",0,"abc@sparta.com","근태관리", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_3.toString(),"이정민 대리","010-1212-1212",0,"abc@sparta.com","근태관리", false, "OFF"))
         totalContactList.add(Contact.Title(1))
-        totalContactList.add(Contact.Person(R.drawable.person_4,"민희정 대리","010-3434-3434",1,"abc@sparta.com","말이 거의 없으신듯", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_5,"마동석 과장","010-3434-3434",1,"abc@sparta.com","주먹 잘 쓰시는", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_4.toString(),"민희정 대리","010-3434-3434",1,"abc@sparta.com","말이 거의 없으신듯", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_5.toString(),"마동석 과장","010-3434-3434",1,"abc@sparta.com","주먹 잘 쓰시는", false, "OFF"))
         totalContactList.add(Contact.Title(2))
-        totalContactList.add(Contact.Person(R.drawable.person_6,"송중기 대리","010-5656-5656",2,"abc@sparta.com","밝게 잘 도와주심", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_7,"박해일 과장","010-5656-5656",2,"abc@sparta.com","무뚝뚝하지만, 도와줄건 도와주시는", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_7,"박해일 과장","010-5656-5656",2,"abc@sparta.com","무뚝뚝하지만, 도와줄건 도와주시는", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_6.toString(),"송중기 대리","010-5656-5656",2,"abc@sparta.com","밝게 잘 도와주심", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_7.toString(),"박해일 과장","010-5656-5656",2,"abc@sparta.com","무뚝뚝하지만, 도와줄건 도와주시는", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_7.toString(),"박해일 과장","010-5656-5656",2,"abc@sparta.com","무뚝뚝하지만, 도와줄건 도와주시는", false, "OFF"))
         totalContactList.add(Contact.Title(3))
-        totalContactList.add(Contact.Person(R.drawable.person_8,"박보겸 사원","010-7878-7878",3,"abc@sparta.com","영업 2등", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_8,"박보겸 사원","010-7878-7878",3,"abc@sparta.com","영업 2등", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_9,"유재석 부장","010-7878-7878",3,"abc@sparta.com","영업 3등", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_9,"유재석 부장","010-7878-7878",3,"abc@sparta.com","영업 3등", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_10,"장원영 대리","010-7878-7878",3,"abc@sparta.com","영업 1등", false, "OFF"))
-        totalContactList.add(Contact.Person(R.drawable.person_10,"장원영 대리","010-7878-7878",3,"abc@sparta.com","영업 1등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_8.toString(),"박보겸 사원","010-7878-7878",3,"abc@sparta.com","영업 2등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_8.toString(),"박보겸 사원","010-7878-7878",3,"abc@sparta.com","영업 2등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_9.toString(),"유재석 부장","010-7878-7878",3,"abc@sparta.com","영업 3등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_9.toString(),"유재석 부장","010-7878-7878",3,"abc@sparta.com","영업 3등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_10.toString(),"장원영 대리","010-7878-7878",3,"abc@sparta.com","영업 1등", false, "OFF"))
+        totalContactList.add(Contact.Person(R.drawable.person_10.toString(),"장원영 대리","010-7878-7878",3,"abc@sparta.com","영업 1등", false, "OFF"))
         totalContactList.add(Contact.Title(4))
         totalContactList.add(Contact.Title(5))
     }
@@ -71,5 +71,9 @@ object ContactStorage {
         }
 
         return count
+    }
+
+    fun checkStartAlphabet(str: String): Boolean {
+        return str[0].isLetter()
     }
 }

--- a/app/src/main/res/layout/dialog_add_contact.xml
+++ b/app/src/main/res/layout/dialog_add_contact.xml
@@ -10,6 +10,8 @@
         android:layout_width="100dp"
         android:layout_height="100dp"
         android:layout_marginTop="32dp"
+        android:background="@drawable/shape_contactlist_circle"
+        android:clipToOutline="true"
         android:src="@drawable/img_default_profile"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
1) Drawable 폴더 내의 이미지와 에뮬레이터 내의 이미지의 저장에서의 호환은 도저히 안 돼서 데이터클래스에서 profileImage를 String 타입으로 변경

2) 더미데이터도 이에 맞춰서 변경

3) 이전 내 정보 수정때와 마찬가지로 photo picker를 사용하여 사진 선택하고 불러옴
- 저장소에 연락처를 저장할 때 프로필 이미지는 Uri를 String타입으로 변경하여 저장

4) 리사이클러뷰 어댑터에서도 위의 변화로 인한 조건문 추가
- 해당 문자열이 Uri면 setImageURI 사용
- 해당 문자열이 Drawable 리소스 ID면 setImageResource 사용

5) 상세 페이지에서도 위의 변화로 인한 조건문 추가
- 해당 문자열이 Uri면 setImageURI 사용
- 해당 문자열이 Drawable 리소스 ID면 setImageResource 사용

6) 저장소에 첫글자가 알파벳인지 확인하는 함수 추가
- Uri는 첫글자가 알파벳이고 Drawable 리소스 아이디의 첫글자는 숫자
- 이를 구분하여 이미지를 이미지뷰에 띄우는 코드를 다르게 하기 위한 함수

Design : 연락처 추가 다이이얼로그 원형 이미지뷰로 변경
1) 배경을 shape_contactlist_circle로 변경

2) ClipToOutline을 true로 추가